### PR TITLE
Add (partial) Python 3 support

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,2 +1,3 @@
 lxml
 cryptography>=1.2.3,<1.3.0
+six

--- a/src/spyne_smev/_base.py
+++ b/src/spyne_smev/_base.py
@@ -17,10 +17,10 @@ from spyne.interface.wsdl.wsdl11 import Wsdl11 as _Wsdl11
 from spyne.model.fault import Fault as _Fault
 from spyne.const.http import HTTP_200
 
-import _utils
-import _xmlns as _ns
-from wsse.protocols import Soap11WSSE
-from fault import ApiError as _ApiError
+from . import _utils
+from . import _xmlns as _ns
+from .wsse.protocols import Soap11WSSE
+from .fault import ApiError as _ApiError
 
 
 class BaseSmev(Soap11WSSE):

--- a/src/spyne_smev/_base.py
+++ b/src/spyne_smev/_base.py
@@ -12,6 +12,7 @@ logger = _logging.getLogger(__name__)
 import os
 
 from lxml import etree as _etree
+from six import text_type
 
 from spyne.interface.wsdl.wsdl11 import Wsdl11 as _Wsdl11
 from spyne.model.fault import Fault as _Fault
@@ -110,7 +111,7 @@ class BaseSmev(Soap11WSSE):
                 error, "{{{0}}}{1}".format(tns, "errorCode")
             ).text = value.errorCode
 
-            if not isinstance(value.errorMessage, unicode):
+            if not isinstance(value.errorMessage, text_type):
                 error_msg = value.errorMessage.decode('UTF-8')
             else:
                 error_msg = value.errorMessage
@@ -132,7 +133,7 @@ class BaseSmev(Soap11WSSE):
                 error, "{{{0}}}{1}".format(ns, "errorCode")
             ).text = inst.errorCode
 
-            if not isinstance(inst.errorMessage, unicode):
+            if not isinstance(inst.errorMessage, text_type):
                 error_msg = inst.errorMessage.decode('UTF-8')
             else:
                 error_msg = inst.errorMessage

--- a/src/spyne_smev/_utils.py
+++ b/src/spyne_smev/_utils.py
@@ -7,10 +7,9 @@ factory.py
 :Author: timic
 """
 import os
-from StringIO import StringIO
 
 from lxml import etree
-from six import binary_type, text_type, PY3
+from six import StringIO, binary_type, text_type, PY3
 from spyne.model.complex import ComplexModelMeta, ComplexModelBase
 
 el_name_with_ns = lambda ns: lambda el: '{%s}%s' % (ns, el)
@@ -22,6 +21,9 @@ class EmptyCtx(object):
         return self.__dict__.get(name, EmptyCtx())
 
     def __nonzero__(self):
+        return False
+
+    def __bool__(self):
         return False
 
 

--- a/src/spyne_smev/application.py
+++ b/src/spyne_smev/application.py
@@ -9,6 +9,8 @@ application.py
 import logging
 logger = logging.getLogger(__name__)
 
+from six import binary_type
+
 from traceback import format_exc
 
 from spyne.model.fault import Fault
@@ -27,13 +29,13 @@ class Application(SpyneApplication):
     def call_wrapper(self, ctx):
         try:
             return super(Application, self).call_wrapper(ctx)
-        except Fault, e:
+        except Fault as e:
             logger.exception(e)
             raise
-        except Exception, e:
-            e_text = unicode(format_exc(), errors="ignore")
+        except Exception as e:
+            e_text = format_exc()
+            if isinstance(e_text, binary_type):
+                e_text = e_text.decode("utf-8", errors="ignore")
             self.event_manager.fire_event("method_call_exception", e_text)
             logger.exception(e)
             raise InternalError(e)
-
-

--- a/src/spyne_smev/client.py
+++ b/src/spyne_smev/client.py
@@ -122,7 +122,7 @@ class _WsseSecurity(_MessagePlugin):
                 out_document = _utils.sign_document(
                     document, self.certificate, self.private_key,
                     self.private_key_password, self.digest_method)
-            except Exception, e:
+            except Exception as e:
                 logger.error("Cannot sign document")
                 logger.exception(e)
                 raise
@@ -140,7 +140,7 @@ class _WsseSecurity(_MessagePlugin):
             try:
                 _utils.verify_document(document, self.in_certificate)
                 self._verified = True
-            except Exception, e:
+            except Exception as e:
                 logger.exception(e)
                 raise
             finally:

--- a/src/spyne_smev/crypto.py
+++ b/src/spyne_smev/crypto.py
@@ -14,7 +14,7 @@ from functools import partial as _partial
 
 from cryptography.hazmat.bindings.openssl.binding import Binding as _Binding
 
-import _utils
+from . import _utils
 
 _binding = _Binding()
 _lib, _ffi = _binding.lib, _binding.ffi

--- a/src/spyne_smev/server/django.py
+++ b/src/spyne_smev/server/django.py
@@ -18,3 +18,6 @@ class DjangoApplication(_SpyneDjangoApplication):
         super(DjangoApplication, self).__init__(
             app, chunked, max_content_length, block_length)
         self.doc = _AllYourInterfaceDocuments(app.interface)
+
+    def set_response(self, retval, response):
+        retval.content = b''.join(response)

--- a/src/spyne_smev/smev256/__init__.py
+++ b/src/spyne_smev/smev256/__init__.py
@@ -14,7 +14,7 @@ from .._utils import EmptyCtx, el_name_with_ns
 from .. fault import ApiError as _ApiError
 from .. import _xmlns as ns
 
-from model import MessageType, ServiceType, HeaderType, AppDocument
+from .model import MessageType, ServiceType, HeaderType, AppDocument
 
 try:
     from spyne.protocol.xml.model import complex_from_element as _spyne_cfe

--- a/src/spyne_smev/wsse/protocols.py
+++ b/src/spyne_smev/wsse/protocols.py
@@ -10,6 +10,8 @@ import logging as _logging
 logger = _logging.getLogger(__name__)
 #TODO: add log messages
 
+from six import text_type
+
 from copy import deepcopy as _deepcopy
 
 from spyne.const import ansi_color as _color
@@ -79,7 +81,7 @@ class X509TokenProfile(BaseWSS):
             return sign_document(
                 envelope, self.certificate, self.private_key,
                 self._private_key_pass, self.digest_method)
-        except ValueError, e:
+        except ValueError as e:
             logger.error(
                 "Error occurred while signing document:\n{0}\n"
                 "Keep it unsigned ...".format(e.message))
@@ -95,12 +97,12 @@ class X509TokenProfile(BaseWSS):
         logger.info("Validate signed document")
         try:
             verify_document(envelope, self.certificate)
-        except (_crypto.Error, ValueError), e:
+        except (_crypto.Error, ValueError) as e:
             logger.error("Signature check failed! Error:\n{0}".format(
-                unicode(e)))
+                text_type(e)))
             raise _Fault(
                 faultstring="Signature check failed! Error:\n{0}".format(
-                    unicode(e)))
+                    text_type(e)))
         except _crypto.InvalidSignature:
             raise _Fault(faultstring="Invalid signature!")
 

--- a/src/spyne_smev/wsse/utils.py
+++ b/src/spyne_smev/wsse/utils.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-"""               
+"""
 utils.py
-                  
-:Created: 03 Jul 2014  
-:Author: tim    
+
+:Created: 03 Jul 2014
+:Author: tim
 """
 
 from copy import deepcopy as _deepcopy
@@ -28,7 +28,7 @@ _c14n_nsmap = {
     (False, True): _xmlns.xml_c14n_wc,
 }
 
-_c14n_params = dict((v, k) for k, v in _c14n_nsmap.iteritems())
+_c14n_params = dict((v, k) for k, v in _c14n_nsmap.items())
 
 _digest_method_nsmap = {
     "md_gost94": _xmlns.gost94,
@@ -279,7 +279,7 @@ def verify_document(document, certificate):
     if not inc_ns is None:
         inc_ns_prefixes = inc_ns.attrib["PrefixList"].split()
         inc_ns_map = dict(
-            (k, v) for k, v in document.nsmap.iteritems()
+            (k, v) for k, v in document.nsmap.items()
             if k in inc_ns_prefixes)
     else:
         inc_ns_map = None
@@ -318,7 +318,7 @@ def verify_document(document, certificate):
     if not inc_ns is None:
         inc_ns_prefixes = inc_ns.attrib["PrefixList"].split()
         inc_ns_map = dict(
-            (k, v) for k, v in document.nsmap.iteritems()
+            (k, v) for k, v in document.nsmap.items()
             if k in inc_ns_prefixes)
     else:
         inc_ns_map = None

--- a/src/spyne_smev/wsse/utils.py
+++ b/src/spyne_smev/wsse/utils.py
@@ -13,6 +13,7 @@ from functools import partial as _partial
 import uuid as _uuid
 
 from lxml import etree as _etree
+import six
 
 from spyne_smev import crypto as _crypto
 from spyne_smev import _utils
@@ -28,7 +29,7 @@ _c14n_nsmap = {
     (False, True): _xmlns.xml_c14n_wc,
 }
 
-_c14n_params = dict((v, k) for k, v in _c14n_nsmap.items())
+_c14n_params = dict((v, k) for k, v in six.iteritems(_c14n_nsmap))
 
 _digest_method_nsmap = {
     "md_gost94": _xmlns.gost94,
@@ -279,7 +280,7 @@ def verify_document(document, certificate):
     if not inc_ns is None:
         inc_ns_prefixes = inc_ns.attrib["PrefixList"].split()
         inc_ns_map = dict(
-            (k, v) for k, v in document.nsmap.items()
+            (k, v) for k, v in six.iteritems(document.nsmap)
             if k in inc_ns_prefixes)
     else:
         inc_ns_map = None
@@ -318,7 +319,7 @@ def verify_document(document, certificate):
     if not inc_ns is None:
         inc_ns_prefixes = inc_ns.attrib["PrefixList"].split()
         inc_ns_map = dict(
-            (k, v) for k, v in document.nsmap.items()
+            (k, v) for k, v in six.iteritems(document.nsmap)
             if k in inc_ns_prefixes)
     else:
         inc_ns_map = None


### PR DESCRIPTION
Hi! I ported a part of this project to Python 3 (using six, with Python 2 backward compatibility). Only SMEV server part (I don't use suds-based client).
Tested with Python 3.5 + spyne 2.11.0 (I couldn't run m3-spyne-smev with newer spyne versions even under Python 2 without my Python 3-related fixes) + Django 1.11 as SMEV service backend. This part of the project seems to work fine.